### PR TITLE
Rework how services are started/stopped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "anyio >=3.6.2,<5",
     "sqlite-anyio >=0.2.0,<0.3.0",
-    "pycrdt >=0.8.7,<0.9.0",
+    "pycrdt >=0.8.16,<0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,61 +1,99 @@
+import subprocess
+from contextlib import asynccontextmanager
 from functools import partial
 from socket import socket
 
 import pytest
 from anyio import Event, create_task_group
+from httpx_ws import aconnect_ws
 from hypercorn import Config
-from pycrdt import Array, Doc
+from pycrdt import Doc
 from sniffio import current_async_library
-from utils import ensure_server_running
+from utils import StartStopContextManager, Websocket, ensure_server_running
 
-from pycrdt_websocket import ASGIServer, WebsocketServer
+from pycrdt_websocket import ASGIServer, WebsocketProvider, WebsocketServer
 
 
-class TestYDoc:
-    def __init__(self):
-        self.ydoc = Doc()
-        self.ydoc["array"] = self.array = Array()
-        self.state = None
-        self.value = 0
-
-    def update(self):
-        self.array.append(self.value)
-        self.value += 1
-        update = self.ydoc.get_update(self.state)
-        self.state = self.ydoc.get_state()
-        return update
+@pytest.fixture(params=("websocket_server_context_manager", "websocket_server_start_stop"))
+def websocket_server_api(request):
+    return request.param
 
 
 @pytest.fixture
-async def yws_server(request, unused_tcp_port):
+async def yws_server(request, unused_tcp_port, websocket_server_api):
     try:
-        kwargs = request.param
-    except AttributeError:
-        kwargs = {}
-    websocket_server = WebsocketServer(**kwargs)
-    app = ASGIServer(websocket_server)
-    config = Config()
-    config.bind = [f"localhost:{unused_tcp_port}"]
-    shutdown_event = Event()
-    if current_async_library() == "trio":
-        from hypercorn.trio import serve
-    else:
-        from hypercorn.asyncio import serve
-    try:
-        async with create_task_group() as tg, websocket_server:
-            tg.start_soon(
-                partial(serve, app, config, shutdown_trigger=shutdown_event.wait, mode="asgi")
-            )
-            await ensure_server_running("localhost", unused_tcp_port)
-            yield unused_tcp_port
-            shutdown_event.set()
+        async with create_task_group() as tg:
+            try:
+                kwargs = request.param
+            except AttributeError:
+                kwargs = {}
+            websocket_server = WebsocketServer(**kwargs)
+            app = ASGIServer(websocket_server)
+            config = Config()
+            config.bind = [f"localhost:{unused_tcp_port}"]
+            shutdown_event = Event()
+            if websocket_server_api == "websocket_server_start_stop":
+                websocket_server = StartStopContextManager(websocket_server, tg)
+            if current_async_library() == "trio":
+                from hypercorn.trio import serve
+            else:
+                from hypercorn.asyncio import serve
+            async with websocket_server as websocket_server:
+                tg.start_soon(
+                    partial(serve, app, config, shutdown_trigger=shutdown_event.wait, mode="asgi")
+                )
+                await ensure_server_running("localhost", unused_tcp_port)
+                pytest.port = unused_tcp_port
+                yield unused_tcp_port
+                shutdown_event.set()
     except Exception:
         pass
 
 
+@pytest.fixture(params=("websocket_provider_context_manager", "websocket_provider_start_stop"))
+def websocket_provider_api(request):
+    return request.param
+
+
 @pytest.fixture
-def test_ydoc():
-    return TestYDoc()
+def yws_provider_factory(room_name, websocket_provider_api):
+    @asynccontextmanager
+    async def factory():
+        ydoc = Doc()
+        async with aconnect_ws(f"http://localhost:{pytest.port}/{room_name}") as websocket:
+            async with create_task_group() as tg:
+                websocket_provider = WebsocketProvider(ydoc, Websocket(websocket, room_name))
+                if websocket_provider_api == "websocket_provider_start_stop":
+                    websocket_provider = StartStopContextManager(websocket_provider, tg)
+                async with websocket_provider as websocket_provider:
+                    yield ydoc
+
+    return factory
+
+
+@pytest.fixture
+async def yws_provider(yws_provider_factory):
+    async with yws_provider_factory() as ydoc:
+        yield ydoc
+
+
+@pytest.fixture
+async def yws_providers(request, yws_provider_factory):
+    number = request.param
+    yield [yws_provider_factory() for idx in range(number)]
+
+
+@pytest.fixture
+def yjs_client(request):
+    client_id = request.param
+    p = subprocess.Popen(["node", f"tests/yjs_client_{client_id}.js", str(pytest.port)])
+    yield p
+    p.kill()
+
+
+@pytest.fixture
+def room_name():
+    return "my-roomname"
 
 
 @pytest.fixture

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -1,32 +1,22 @@
 import pytest
 from anyio import sleep
-from httpx_ws import aconnect_ws
-from pycrdt import Doc, Map
-from utils import Websocket
-
-from pycrdt_websocket import WebsocketProvider
+from pycrdt import Map
 
 pytestmark = pytest.mark.anyio
 
 
 @pytest.mark.parametrize("yws_server", [{"auto_clean_rooms": False}], indirect=True)
-async def test_asgi(yws_server):
-    port = yws_server
+@pytest.mark.parametrize("yws_providers", [2], indirect=True)
+async def test_asgi(yws_server, yws_providers):
+    yws_provider1, yws_provider2 = yws_providers
     # client 1
-    ydoc1 = Doc()
-    ydoc1["map"] = ymap1 = Map()
-    ymap1["key"] = "value"
-    async with aconnect_ws(
-        f"http://localhost:{port}/my-roomname"
-    ) as websocket1, WebsocketProvider(ydoc1, Websocket(websocket1, "my-roomname")):
+    async with yws_provider1 as ydoc1:
+        ydoc1["map"] = ymap1 = Map()
+        ymap1["key"] = "value"
         await sleep(0.1)
 
     # client 2
-    ydoc2 = Doc()
-    async with aconnect_ws(
-        f"http://localhost:{port}/my-roomname"
-    ) as websocket2, WebsocketProvider(ydoc2, Websocket(websocket2, "my-roomname")):
+    async with yws_provider2 as ydoc2:
+        ymap2 = ydoc2.get("map", type=Map)
         await sleep(0.1)
-
-    ydoc2["map"] = ymap2 = Map()
-    assert str(ymap2) == '{"key":"value"}'
+        assert str(ymap2) == '{"key":"value"}'

--- a/tests/test_pycrdt_yjs.py
+++ b/tests/test_pycrdt_yjs.py
@@ -4,27 +4,23 @@ from functools import partial
 
 import pytest
 from anyio import Event, fail_after
-from httpx_ws import aconnect_ws
-from pycrdt import Array, Doc, Map
-from utils import Websocket, yjs_client
-
-from pycrdt_websocket import WebsocketProvider
+from pycrdt import Array, Map
 
 pytestmark = pytest.mark.anyio
 
 
 class Change:
-    def __init__(self, event, timeout, ydata, sid, key):
+    def __init__(self, event, timeout, ydata, subscription, key):
         self.event = event
         self.timeout = timeout
         self.ydata = ydata
-        self.sid = sid
+        self.subscription = subscription
         self.key = key
 
     async def wait(self):
         with fail_after(self.timeout):
             await self.event.wait()
-        self.ydata.unobserve(self.sid)
+        self.ydata.unobserve(self.subscription)
         if self.key is None:
             return
         return self.ydata[self.key]
@@ -37,36 +33,28 @@ def callback(change_event, key, event):
 
 def watch(ydata, key: str | None = None, timeout: float = 1.0):
     change_event = Event()
-    sid = ydata.observe(partial(callback, change_event, key))
-    return Change(change_event, timeout, ydata, sid, key)
+    subscription = ydata.observe(partial(callback, change_event, key))
+    return Change(change_event, timeout, ydata, subscription, key)
 
 
-async def test_pycrdt_yjs_0(yws_server):
-    port = yws_server
-    with yjs_client(0, port):
-        ydoc = Doc()
-        async with aconnect_ws(
-            f"http://localhost:{port}/my-roomname"
-        ) as websocket, WebsocketProvider(ydoc, Websocket(websocket, "my-roomname")):
-            ydoc["map"] = ymap = Map()
-            for v_in in range(10):
-                ymap["in"] = float(v_in)
-                v_out = await watch(ymap, "out").wait()
-                assert v_out == v_in + 1.0
+@pytest.mark.parametrize("yjs_client", [0], indirect=True)
+async def test_pycrdt_yjs_0(yws_server, yws_provider, yjs_client):
+    ydoc = yws_provider
+    ydoc["map"] = ymap = Map()
+    for v_in in range(10):
+        ymap["in"] = float(v_in)
+        v_out = await watch(ymap, "out").wait()
+        assert v_out == v_in + 1.0
 
 
-async def test_pycrdt_yjs_1(yws_server):
-    port = yws_server
-    with yjs_client(1, port):
-        ydoc = Doc()
-        ydoc["cells"] = ycells = Array()
-        ydoc["state"] = ystate = Map()
-        ycells_change = watch(ycells)
-        ystate_change = watch(ystate)
-        async with aconnect_ws(
-            f"http://localhost:{port}/my-roomname"
-        ) as websocket, WebsocketProvider(ydoc, Websocket(websocket, "my-roomname")):
-            await ycells_change.wait()
-            await ystate_change.wait()
-            assert ycells.to_py() == [{"metadata": {"foo": "bar"}, "source": "1 + 2"}]
-            assert ystate.to_py() == {"state": {"dirty": False}}
+@pytest.mark.parametrize("yjs_client", [1], indirect=True)
+async def test_pycrdt_yjs_1(yws_server, yws_provider, yjs_client):
+    ydoc = yws_provider
+    ydoc["cells"] = ycells = Array()
+    ydoc["state"] = ystate = Map()
+    ycells_change = watch(ycells)
+    ystate_change = watch(ystate)
+    await ycells_change.wait()
+    await ystate_change.wait()
+    assert ycells.to_py() == [{"metadata": {"foo": "bar"}, "source": "1 + 2"}]
+    assert ystate.to_py() == {"state": {"dirty": False}}

--- a/tests/test_ystore.py
+++ b/tests/test_ystore.py
@@ -1,15 +1,18 @@
-import os
 import tempfile
 import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from anyio import create_task_group
 from sqlite_anyio import connect
+from utils import StartStopContextManager, YDocTest
 
 from pycrdt_websocket.ystore import SQLiteYStore, TempFileYStore
 
 pytestmark = pytest.mark.anyio
+
+MY_SQLITE_YSTORE_DB_PATH = str(Path(tempfile.mkdtemp(prefix="test_sql_")) / "ystore.db")
 
 
 class MetadataCallback:
@@ -25,80 +28,99 @@ class MetadataCallback:
 class MyTempFileYStore(TempFileYStore):
     prefix_dir = "test_temp_"
 
-
-MY_SQLITE_YSTORE_DB_PATH = str(Path(tempfile.mkdtemp(prefix="test_sql_")) / "ystore.db")
+    def __init__(self, *args, delete=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        if delete:
+            Path(self.path).unlink(missing_ok=True)
 
 
 class MySQLiteYStore(SQLiteYStore):
     db_path = MY_SQLITE_YSTORE_DB_PATH
     document_ttl = 1000
 
-    def __init__(self, *args, delete_db=False, **kwargs):
-        if delete_db:
-            os.remove(self.db_path)
+    def __init__(self, *args, delete=False, **kwargs):
+        if delete:
+            Path(self.db_path).unlink(missing_ok=True)
         super().__init__(*args, **kwargs)
 
 
 @pytest.mark.parametrize("YStore", (MyTempFileYStore, MySQLiteYStore))
-async def test_ystore(YStore):
-    store_name = "my_store"
-    ystore = YStore(store_name, metadata_callback=MetadataCallback())
-    await ystore.start()
-    data = [b"foo", b"bar", b"baz"]
-    for d in data:
-        await ystore.write(d)
+@pytest.mark.parametrize("ystore_api", ("ystore_context_manager", "ystore_start_stop"))
+async def test_ystore(YStore, ystore_api):
+    async with create_task_group() as tg:
+        store_name = f"my_store_with_api_{ystore_api}"
+        ystore = YStore(store_name, metadata_callback=MetadataCallback(), delete=True)
+        if ystore_api == "ystore_start_stop":
+            ystore = StartStopContextManager(ystore, tg)
 
-    if YStore == MyTempFileYStore:
-        assert (Path(MyTempFileYStore.base_dir) / store_name).exists()
-    elif YStore == MySQLiteYStore:
-        assert Path(MySQLiteYStore.db_path).exists()
-    i = 0
-    async for d, m, t in ystore.read():
-        assert d == data[i]  # data
-        assert m == str(i).encode()  # metadata
-        i += 1
+        async with ystore as ystore:
+            data = [b"foo", b"bar", b"baz"]
+            for d in data:
+                await ystore.write(d)
 
-    assert i == len(data)
+            if YStore == MyTempFileYStore:
+                assert (Path(MyTempFileYStore.base_dir) / store_name).exists()
+            elif YStore == MySQLiteYStore:
+                assert Path(MySQLiteYStore.db_path).exists()
+            i = 0
+            async for d, m, t in ystore.read():
+                assert d == data[i]  # data
+                assert m == str(i).encode()  # metadata
+                i += 1
 
-    await ystore.stop()
+            assert i == len(data)
 
 
-async def test_document_ttl_sqlite_ystore(test_ydoc):
-    store_name = "my_store"
-    ystore = MySQLiteYStore(store_name, delete_db=True)
-    await ystore.start()
-    now = time.time()
-    db = await connect(ystore.db_path)
-    cursor = await db.cursor()
+@pytest.mark.parametrize("ystore_api", ("ystore_context_manager", "ystore_start_stop"))
+async def test_document_ttl_sqlite_ystore(ystore_api):
+    async with create_task_group() as tg:
+        test_ydoc = YDocTest()
+        store_name = f"my_store_with_api_{ystore_api}"
+        ystore = MySQLiteYStore(store_name, delete=True)
+        if ystore_api == "ystore_start_stop":
+            ystore = StartStopContextManager(ystore, tg)
 
-    for i in range(3):
-        # assert that adding a record before document TTL doesn't delete document history
-        with patch("time.time") as mock_time:
-            mock_time.return_value = now
-            await ystore.write(test_ydoc.update())
-            assert (await (await cursor.execute("SELECT count(*) FROM yupdates")).fetchone())[
-                0
-            ] == i + 1
+        async with ystore as ystore:
+            now = time.time()
+            db = await connect(ystore.db_path)
+            cursor = await db.cursor()
 
-    # assert that adding a record after document TTL deletes previous document history
-    with patch("time.time") as mock_time:
-        mock_time.return_value = now + ystore.document_ttl + 1
-        await ystore.write(test_ydoc.update())
-        # two updates in DB: one squashed update and the new update
-        assert (await (await cursor.execute("SELECT count(*) FROM yupdates")).fetchone())[0] == 2
+            for i in range(3):
+                # assert that adding a record before document TTL doesn't delete document history
+                with patch("time.time") as mock_time:
+                    mock_time.return_value = now
+                    await ystore.write(test_ydoc.update())
+                    assert (
+                        await (await cursor.execute("SELECT count(*) FROM yupdates")).fetchone()
+                    )[0] == i + 1
 
-    await db.close()
-    await ystore.stop()
+            # assert that adding a record after document TTL deletes previous document history
+            with patch("time.time") as mock_time:
+                mock_time.return_value = now + ystore.document_ttl + 1
+                await ystore.write(test_ydoc.update())
+                # two updates in DB: one squashed update and the new update
+                assert (await (await cursor.execute("SELECT count(*) FROM yupdates")).fetchone())[
+                    0
+                ] == 2
+
+            await db.close()
 
 
 @pytest.mark.parametrize("YStore", (MyTempFileYStore, MySQLiteYStore))
-async def test_version(YStore, caplog):
-    store_name = "my_store"
-    prev_version = YStore.version
-    YStore.version = -1
-    ystore = YStore(store_name)
-    await ystore.start()
-    await ystore.write(b"foo")
-    YStore.version = prev_version
-    assert "YStore version mismatch" in caplog.text
-    await ystore.stop()
+@pytest.mark.parametrize("ystore_api", ("ystore_context_manager", "ystore_start_stop"))
+async def test_version(YStore, ystore_api, caplog):
+    async with create_task_group() as tg:
+        store_name = f"my_store_with_api_{ystore_api}"
+        prev_version = YStore.version
+        YStore.version = -1
+        ystore = YStore(store_name)
+        if ystore_api == "ystore_start_stop":
+            ystore = StartStopContextManager(ystore, tg)
+
+        async with ystore as ystore:
+            await ystore.write(b"foo")
+            assert "YStore version mismatch" in caplog.text
+
+        YStore.version = prev_version
+        async with ystore as ystore:
+            await ystore.write(b"bar")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,34 @@
-import subprocess
-from contextlib import contextmanager
-
 from anyio import Lock, connect_tcp
+from pycrdt import Array, Doc
+
+
+class YDocTest:
+    def __init__(self):
+        self.ydoc = Doc()
+        self.ydoc["array"] = self.array = Array()
+        self.state = None
+        self.value = 0
+
+    def update(self):
+        self.array.append(self.value)
+        self.value += 1
+        update = self.ydoc.get_update(self.state)
+        self.state = self.ydoc.get_state()
+        return update
+
+
+class StartStopContextManager:
+    def __init__(self, service, task_group):
+        self._service = service
+        self._task_group = task_group
+
+    async def __aenter__(self):
+        await self._task_group.start(self._service.start)
+        await self._service.started.wait()
+        return self._service
+
+    async def __aexit__(self, exc_type, exc_value, exc_tb):
+        await self._service.stop()
 
 
 class Websocket:
@@ -31,13 +58,6 @@ class Websocket:
     async def recv(self) -> bytes:
         b = await self._websocket.receive_bytes()
         return bytes(b)
-
-
-@contextmanager
-def yjs_client(client_id: int, port: int):
-    p = subprocess.Popen(["node", f"tests/yjs_client_{client_id}.js", str(port)])
-    yield p
-    p.kill()
 
 
 async def ensure_server_running(host: str, port: int) -> None:


### PR DESCRIPTION
# Description

`pycrdt-websocket` provides these 4 services:
- `WebsocketServer`: a WebSocket server.
- `WebsocketProvider`: a WebSocker provider (a client to a `WebsocketServer`).
- `YStore`: a store for persisting Y updates.
- `YRoom`: a room where clients collaborate on a Y document.

These services are asynchronous, and have to be started (for initialization) and stopped (for teardown). For instance, initialization could include connecting to a database, and teardown could disconnect from the database.
They provide 2 common APIs to be started and stopped:
- an async context manager.
- individual `start()` and `stop()` async methods.

The async context manager API looks like this:
```py
async def main():
    async with WebsocketServer() as websocket_server:
        ...
```
And the start/stop API looks like this (using AnyIO):
```py
async def main():
    websocket_server = WebsocketServer()
    async with create_task_group() as tg:
        await tg.start(websocket_server.start)
        ...
        await websocket_server.stop()
```
In an environment where it is not possible to use AnyIO task groups, once can use `asyncio` like this:
```py
async def main():
    websocket_server = WebsocketServer()
    task = asyncio.create_task(websocket_server.start())
    await websocket_server.started.wait()
    ...
    await websocket_server.stop()
```
While it is advised to use the async context manager API, it is not always possible to do so, hence the manual start/stop methods.

# Improvements

The way services are started and stopped now uses an `anyio.Lock`, instead of a boolean attribute `_starting`, to handle concurrent calls. Also, `__aenter__()` calls `start()` under the hood, and `__aexit__()` calls `stop()`, instead of copying code. This ensures that both ways are equivalent. The `start()` method is passed a parameter `from_context_manager=True` if called from `__aenter__()`, in order to not create a new task group, since it was already created in `__aenter__()`.

Tests have also been reworked, so that both APIs (context manager and start/stop methods) of every service are tested. Also, since #22 both `asyncio` and `trio` backends are tested.

# Breaking changes

This PR has the following breaking changes:
- the `stop()` methods are now async. It didn't make a lot of sense to have `start()` async and not `stop()`, and teardown could have async logic in general.
- `WebsocketServer.delete_room()` is now async, since it may stop a room, and stopping a room is async.