### PR TITLE
adding exception handling for room start tasks

### DIFF
--- a/pycrdt_websocket/yroom.py
+++ b/pycrdt_websocket/yroom.py
@@ -145,10 +145,10 @@ class YRoom:
                         self._task_group.start_soon(client.send, message)
                     except Exception as e:
                         self.log.error(
-                             "Error sending Y update to client with endpoint: %s",
-                             client.path,
-                             exc_info=e,
-                         )
+                            "Error sending Y update to client with endpoint: %s",
+                            client.path,
+                            exc_info=e,
+                        )
                         if isinstance(e, WebSocketClosedError):
                             self.client.remove(client)
                 if self.ystore:


### PR DESCRIPTION
Sometimes, we have observed issues that task group in websocket_server is no longer active and user will be stuck after that and no longer able to access files and have to restart nb servers to unblock. `_task_group` instance variable in websocket_server will become inactive when one of its tasks of starting room or its children task group task fail with exception.

One place where an exception can occur is in the [`_broadcast_update`](https://github.com/jupyter-server/pycrdt-websocket/blob/07737264b4427b7369b13ebf0ddd0d8f0f82d088/pycrdt_websocket/yroom.py#L122) method, which is a key task in children task group of `_task_group` in websocket_server. In this PR, the exception is handled and logged to prevent the parent task from crashing while still displaying the issue that will allow us better handle them in the future.

Resolving open source issues:
https://github.com/jupyterlab/jupyter-collaboration/issues/290
https://github.com/jupyterlab/jupyter-collaboration/issues/245