### PR TITLE
Add WebsocketServer exception handler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           mypy pycrdt_websocket tests
       - name: Run tests
         run: |
-          pytest -v
+          pytest -v --color=yes
 
   check_release:
     runs-on: ubuntu-latest

--- a/pycrdt_websocket/__init__.py
+++ b/pycrdt_websocket/__init__.py
@@ -1,7 +1,8 @@
 from .asgi_server import ASGIServer as ASGIServer
 from .websocket_provider import WebsocketProvider as WebsocketProvider
 from .websocket_server import WebsocketServer as WebsocketServer
-from .websocket_server import YRoom as YRoom
+from .websocket_server import exception_logger as exception_logger
+from .yroom import YRoom as YRoom
 from .yutils import YMessageType as YMessageType
 
 __version__ = "0.13.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ async def yws_server(request, unused_tcp_port, websocket_server_api):
                 )
                 await ensure_server_running("localhost", unused_tcp_port)
                 pytest.port = unused_tcp_port
-                yield unused_tcp_port
+                yield unused_tcp_port, websocket_server
                 shutdown_event.set()
     except Exception:
         pass

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,13 @@
 import pytest
 from anyio import sleep
 
+from pycrdt_websocket import exception_logger
+
 pytestmark = pytest.mark.anyio
 
 
 @pytest.mark.parametrize("websocket_server_api", ["websocket_server_start_stop"], indirect=True)
-@pytest.mark.parametrize("yws_server", [{"auto_restart": True}], indirect=True)
+@pytest.mark.parametrize("yws_server", [{"exception_handler": exception_logger}], indirect=True)
 async def test_server_restart(yws_server):
     port, server = yws_server
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,16 @@
+import pytest
+from anyio import sleep
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.mark.parametrize("websocket_server_api", ["websocket_server_start_stop"], indirect=True)
+@pytest.mark.parametrize("yws_server", [{"auto_restart": True}], indirect=True)
+async def test_server_restart(yws_server):
+    port, server = yws_server
+
+    async def raise_error():
+        raise RuntimeError("foo")
+
+    server._task_group.start_soon(raise_error)
+    await sleep(0.1)


### PR DESCRIPTION
The ability to auto-restart is only supported when using the start/stop API for now, not the context manager.
It does so by catching exceptions and re-creating a new task group.