### PR TITLE
adding exception handling for room start tasks

### DIFF
--- a/tests/test_yroom.py
+++ b/tests/test_yroom.py
@@ -1,0 +1,33 @@
+import pytest
+from anyio import TASK_STATUS_IGNORED, sleep
+from anyio.abc import TaskStatus
+from pycrdt import Map
+
+from pycrdt_websocket import exception_logger
+from pycrdt_websocket.yroom import YRoom
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.mark.parametrize("websocket_server_api", ["websocket_server_start_stop"], indirect=True)
+@pytest.mark.parametrize("yws_server", [{"exception_handler": exception_logger}], indirect=True)
+async def test_yroom_restart(yws_server, yws_provider):
+    port, server = yws_server
+    yroom = YRoom(exception_handler=exception_logger)
+
+    async def raise_error(task_status: TaskStatus[None] = TASK_STATUS_IGNORED):
+        task_status.started()
+        raise RuntimeError("foo")
+
+    yroom.ydoc = yws_provider
+    await server.start_room(yroom)
+    yroom.ydoc["map"] = ymap1 = Map()
+    ymap1["key"] = "value"
+    task_group_1 = yroom._task_group
+    await yroom._task_group.start(raise_error)
+    ymap1["key2"] = "value2"
+    await sleep(0.1)
+    assert yroom._task_group is not task_group_1
+    assert yroom._task_group is not None
+    assert not yroom._task_group.cancel_scope.cancel_called
+    await yroom.stop()


### PR DESCRIPTION
Sometimes, we have observed issues that task group in websocket_server is no longer active and user will be stuck after that and no longer able to access files and have to restart nb servers to unblock. _task_group instance variable in websocket_server will become inactive when one of its tasks of starting room or its children task group task fail with exception.

One place where an exception can occur is in the [_broadcast_update](https://github.com/jupyter-server/pycrdt-websocket/blob/07737264b4427b7369b13ebf0ddd0d8f0f82d088/pycrdt_websocket/yroom.py#L122) method, which is a key task in children task group of _task_group in websocket_server. In this PR, the exception is handled and logged to prevent the parent task from crashing while still displaying the issue that will allow us better handle them in the future.

Resolving open source issues:
https://github.com/jupyterlab/jupyter-collaboration/issues/290
https://github.com/jupyterlab/jupyter-collaboration/issues/245