### PR TITLE
Allow efficient trimming of history

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.8.3
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.11.0
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.8.0
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.8.6
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.9.4
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.8.1
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.7
+    rev: v0.9.9
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.4
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.11.2
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.7.3
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.7.2
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.9.7
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.7.4
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.1
+    rev: v0.8.2
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.9.3
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.2
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.9.10
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.15.2
+
+([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.15.1...d208ff03390d17e0dc3e438e39d0af150b3f7d93))
+
+### Bugs fixed
+
+- Remove client on failure [#94](https://github.com/jupyter-server/pycrdt-websocket/pull/94) ([@darabos](https://github.com/darabos))
+
+### Maintenance and upkeep improvements
+
+- Dead code [#89](https://github.com/jupyter-server/pycrdt-websocket/pull/89) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Update client documentation [#91](https://github.com/jupyter-server/pycrdt-websocket/pull/91) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-10-14&to=2024-12-10&type=c))
+
+[@darabos](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adarabos+updated%3A2024-10-14..2024-12-10&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adavidbrochart+updated%3A2024-10-14..2024-12-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Afcollonval+updated%3A2024-10-14..2024-12-10&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Apre-commit-ci+updated%3A2024-10-14..2024-12-10&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.15.1
 
 ([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.15.0...b43acfd307f4af68efc6bc460e9e597748cdf59e))
@@ -15,8 +39,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-10-09&to=2024-10-14&type=c))
 
 [@brichet](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Abrichet+updated%3A2024-10-09..2024-10-14&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.15.1
+
+([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.15.0...b43acfd307f4af68efc6bc460e9e597748cdf59e))
+
+### Enhancements made
+
+- Start the server awareness [#78](https://github.com/jupyter-server/pycrdt-websocket/pull/78) ([@brichet](https://github.com/brichet))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-10-09&to=2024-10-14&type=c))
+
+[@brichet](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Abrichet+updated%3A2024-10-09..2024-10-14&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.15.0
 
 ([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.14.3...e361683b4752cedce933c362c510e40302865dc4))
@@ -21,8 +37,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-10-04&to=2024-10-09&type=c))
 
 [@brichet](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Abrichet+updated%3A2024-10-04..2024-10-09&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adavidbrochart+updated%3A2024-10-04..2024-10-09&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Apre-commit-ci+updated%3A2024-10-04..2024-10-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.14.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.15.3
+
+([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.15.2...3a74f65bd4d0e27634ec035699828e1cf80bd036))
+
+### Documentation improvements
+
+- Update client/server examples [#95](https://github.com/jupyter-server/pycrdt-websocket/pull/95) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-12-10&to=2024-12-10&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adavidbrochart+updated%3A2024-12-10..2024-12-10&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.15.2
 
 ([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.15.1...d208ff03390d17e0dc3e438e39d0af150b3f7d93))
@@ -23,8 +39,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-10-14&to=2024-12-10&type=c))
 
 [@darabos](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adarabos+updated%3A2024-10-14..2024-12-10&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adavidbrochart+updated%3A2024-10-14..2024-12-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Afcollonval+updated%3A2024-10-14..2024-12-10&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Apre-commit-ci+updated%3A2024-10-14..2024-12-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.15.4
+
+([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.15.3...4c9f21a9e75d7f726f293674abee820837e44ea7))
+
+### Maintenance and upkeep improvements
+
+- Increase pycrdt compatible version range [#104](https://github.com/jupyter-server/pycrdt-websocket/pull/104) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-12-10&to=2025-01-23&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adavidbrochart+updated%3A2024-12-10..2025-01-23&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Afcollonval+updated%3A2024-12-10..2025-01-23&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Apre-commit-ci+updated%3A2024-12-10..2025-01-23&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.15.3
 
 ([Full Changelog](https://github.com/jupyter-server/pycrdt-websocket/compare/v0.15.2...3a74f65bd4d0e27634ec035699828e1cf80bd036))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/pycrdt-websocket/graphs/contributors?from=2024-12-10&to=2024-12-10&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fpycrdt-websocket+involves%3Adavidbrochart+updated%3A2024-12-10..2024-12-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.15.2
 

--- a/docs/usage/client.md
+++ b/docs/usage/client.md
@@ -1,14 +1,15 @@
-A client connects their `YDoc` through a [WebsocketProvider](../reference/WebSocket_provider.md).
+A client connects their `Doc` through a [WebsocketProvider](../reference/WebSocket_provider.md).
 
 Here is a code example using the [websockets](https://websockets.readthedocs.io) library:
 ```py
 import asyncio
-import y_py as Y
 from websockets import connect
+from pycrdt import Doc, Map
 from pycrdt_websocket import WebsocketProvider
 
 async def client():
-    ydoc = Y.YDoc()
+    ydoc = Doc()
+    ymap = ydoc.get("map", type=Map)
     async with (
         connect("ws://localhost:1234/my-roomname") as websocket,
         WebsocketProvider(ydoc, websocket),
@@ -16,9 +17,7 @@ async def client():
         # Changes to remote ydoc are applied to local ydoc.
         # Changes to local ydoc are sent over the WebSocket and
         # broadcast to all clients.
-        ymap = ydoc.get_map("map")
-        with ydoc.begin_transaction() as t:
-            ymap.set(t, "key", "value")
+        ymap["key"] = "value"
 
         await asyncio.Future()  # run forever
 

--- a/docs/usage/client.md
+++ b/docs/usage/client.md
@@ -1,18 +1,20 @@
 A client connects their `Doc` through a [WebsocketProvider](../reference/WebSocket_provider.md).
 
-Here is a code example using the [websockets](https://websockets.readthedocs.io) library:
+Here is a code example using the [httpx-ws](https://frankie567.github.io/httpx-ws) library:
 ```py
 import asyncio
-from websockets import connect
+from httpx_ws import aconnect_ws
 from pycrdt import Doc, Map
 from pycrdt_websocket import WebsocketProvider
+from pycrdt_websocket.websocket import HttpxWebsocket
 
 async def client():
     ydoc = Doc()
     ymap = ydoc.get("map", type=Map)
+    room_name = "my-roomname"
     async with (
-        connect("ws://localhost:1234/my-roomname") as websocket,
-        WebsocketProvider(ydoc, websocket),
+        aconnect_ws(f"http://localhost:1234/{room_name}") as websocket,
+        WebsocketProvider(ydoc, HttpxWebsocket(websocket, room_name)),
     ):
         # Changes to remote ydoc are applied to local ydoc.
         # Changes to local ydoc are sent over the WebSocket and

--- a/pycrdt_websocket/__init__.py
+++ b/pycrdt_websocket/__init__.py
@@ -4,4 +4,4 @@ from .websocket_server import WebsocketServer as WebsocketServer
 from .websocket_server import exception_logger as exception_logger
 from .yroom import YRoom as YRoom
 
-__version__ = "0.15.2"
+__version__ = "0.15.3"

--- a/pycrdt_websocket/__init__.py
+++ b/pycrdt_websocket/__init__.py
@@ -4,4 +4,4 @@ from .websocket_server import WebsocketServer as WebsocketServer
 from .websocket_server import exception_logger as exception_logger
 from .yroom import YRoom as YRoom
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/pycrdt_websocket/__init__.py
+++ b/pycrdt_websocket/__init__.py
@@ -4,4 +4,4 @@ from .websocket_server import WebsocketServer as WebsocketServer
 from .websocket_server import exception_logger as exception_logger
 from .yroom import YRoom as YRoom
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/pycrdt_websocket/__init__.py
+++ b/pycrdt_websocket/__init__.py
@@ -4,4 +4,4 @@ from .websocket_server import WebsocketServer as WebsocketServer
 from .websocket_server import exception_logger as exception_logger
 from .yroom import YRoom as YRoom
 
-__version__ = "0.15.3"
+__version__ = "0.15.4"

--- a/pycrdt_websocket/websocket.py
+++ b/pycrdt_websocket/websocket.py
@@ -1,5 +1,7 @@
 from typing import Protocol
 
+from anyio import Lock
+
 
 class Websocket(Protocol):
     """WebSocket.
@@ -51,3 +53,32 @@ class Websocket(Protocol):
             The received message.
         """
         ...
+
+
+class HttpxWebsocket(Websocket):
+    def __init__(self, websocket, path: str):
+        self._websocket = websocket
+        self._path = path
+        self._send_lock = Lock()
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        try:
+            message = await self.recv()
+        except Exception:
+            raise StopAsyncIteration()
+        return message
+
+    async def send(self, message: bytes):
+        async with self._send_lock:
+            await self._websocket.send_bytes(message)
+
+    async def recv(self) -> bytes:
+        b = await self._websocket.receive_bytes()
+        return bytes(b)

--- a/pycrdt_websocket/websocket_provider.py
+++ b/pycrdt_websocket/websocket_provider.py
@@ -73,8 +73,6 @@ class WebsocketProvider:
             self._started = Event()
         return self._started
 
-        return self
-
     @property
     def _start_lock(self) -> Lock:
         if self.__start_lock is None:

--- a/pycrdt_websocket/yroom.py
+++ b/pycrdt_websocket/yroom.py
@@ -309,10 +309,11 @@ class YRoom:
                             tg.start_soon(client.send, message)
                         # apply awareness update to the server's awareness
                         self.awareness.apply_awareness_update(read_message(message[1:]), self)
-                # remove this client
-                self.clients.remove(websocket)
         except Exception as exception:
             self._handle_exception(exception)
+        finally:
+            # remove this client
+            self.clients.remove(websocket)
 
     def send_server_awareness(self, type: str, changes: tuple[dict[str, Any], Any]) -> None:
         """

--- a/pycrdt_websocket/yroom.py
+++ b/pycrdt_websocket/yroom.py
@@ -213,6 +213,7 @@ class YRoom:
             self._task_group.start_soon(self._stopped.wait)
             self._task_group.start_soon(self._watch_ready)
             self._task_group.start_soon(self._broadcast_updates)
+            self._task_group.start_soon(self.awareness.start)
             return
 
         async with self._start_lock:
@@ -231,8 +232,10 @@ class YRoom:
                         self._task_group.start_soon(self._stopped.wait)
                         self._task_group.start_soon(self._watch_ready)
                         self._task_group.start_soon(self._broadcast_updates)
+                        self._task_group.start_soon(self.awareness.start)
                     return
                 except Exception as exception:
+                    await self.awareness.stop()
                     self._handle_exception(exception)
 
     async def stop(self) -> None:
@@ -240,6 +243,7 @@ class YRoom:
         if self._task_group is None:
             raise RuntimeError("YRoom not running")
         self._stopped.set()
+        await self.awareness.stop()
         self._task_group.cancel_scope.cancel()
         self._task_group = None
         if self._subscription is not None:

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -493,6 +493,7 @@ class SQLiteYStore(BaseYStore):
                 ):
                     # squash updates
                     ydoc: Doc = Doc()
+
                     older_than = time.time() - (
                         self.history_length if self.history_length is not None else 0
                     )

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -324,7 +324,7 @@ class SQLiteYStore(BaseYStore):
     # Defaults to never purging document history (None).
     document_ttl: int | None = None
     # The maximum length of the history of the documents in seconds that is kept.
-    history_length: int | None = 120
+    history_length: int | None = None
     # The minimum interval in seconds between history cleanup operations.
     min_cleanup_interval: int = 60
     path: str

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -488,7 +488,7 @@ class SQLiteYStore(BaseYStore):
 
                 if self.document_ttl is not None and diff > self.document_ttl:
                     # squash updates
-                    ydoc = Doc()
+                    ydoc: Doc = Doc()
                     await cursor.execute(
                         "SELECT yupdate FROM yupdates WHERE path = ?",
                         (self.path,),

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -9,7 +9,7 @@ from functools import partial
 from inspect import isawaitable
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import AsyncIterator, Awaitable, Callable, cast
+from typing import AsyncIterator, Awaitable, Callable, cast, Literal
 
 import anyio
 from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group
@@ -323,6 +323,10 @@ class SQLiteYStore(BaseYStore):
     # latest update of a document must be before purging document history.
     # Defaults to never purging document history (None).
     document_ttl: int | None = None
+    # The maximum length of the history of the documents in seconds that is kept.
+    history_length: int | None = 120
+    # The minimum interval in seconds between history cleanup operations.
+    min_cleanup_interval: int = 60
     path: str
     lock: Lock
     db_initialized: Event | None
@@ -478,25 +482,27 @@ class SQLiteYStore(BaseYStore):
             async with self._db:
                 # first, determine time elapsed since last update
                 cursor = await self._db.cursor()
-                await cursor.execute(
-                    "SELECT timestamp FROM yupdates WHERE path = ? "
-                    "ORDER BY timestamp DESC LIMIT 1",
-                    (self.path,),
-                )
-                row = await cursor.fetchone()
-                diff = (time.time() - row[0]) if row else 0
 
-                if self.document_ttl is not None and diff > self.document_ttl:
+                newest_diff = await self._get_time_differential_to_entry(cursor, direction="DESC")
+                oldest_diff = await self._get_time_differential_to_entry(cursor, direction="ASC")
+
+                squashed = False
+                if (self.document_ttl is not None and newest_diff > self.document_ttl) or (
+                    self.history_length is not None and oldest_diff > self.min_cleanup_interval + self.history_length
+                ):
                     # squash updates
                     ydoc = Doc()
+                    older_than = time.time() - self.history_length
                     await cursor.execute(
-                        "SELECT yupdate FROM yupdates WHERE path = ?",
-                        (self.path,),
+                        "SELECT yupdate FROM yupdates WHERE path = ? AND timestamp < ?",
+                        (self.path, older_than),
                     )
                     for (update,) in await cursor.fetchall():
                         ydoc.apply_update(update)
-                    # delete history
-                    await cursor.execute("DELETE FROM yupdates WHERE path = ?", (self.path,))
+                    # delete older history
+                    await cursor.execute(
+                        "DELETE FROM yupdates WHERE path = ? AND timestamp < ?", (self.path, older_than)
+                    )
                     # insert squashed updates
                     squashed_update = ydoc.get_update()
                     metadata = await self.get_metadata()
@@ -504,6 +510,7 @@ class SQLiteYStore(BaseYStore):
                         "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
                         (self.path, squashed_update, metadata, time.time()),
                     )
+                    squashed = True
 
                 # finally, write this update to the DB
                 metadata = await self.get_metadata()
@@ -511,3 +518,17 @@ class SQLiteYStore(BaseYStore):
                     "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
                     (self.path, data, metadata, time.time()),
                 )
+
+                if squashed:
+                    # Vacuuming database
+                    await self._db.commit()
+                    await cursor.execute("VACUUM")
+
+    async def _get_time_differential_to_entry(self, cursor, direction: Literal["ASC", "DESC"] = "DESC") -> float:
+        """ Get the time differential to the newest (DESC) or oldest (ASC) entry in the database. """
+        await cursor.execute(
+            "SELECT timestamp FROM yupdates WHERE path = ? " f"ORDER BY timestamp {direction} LIMIT 1",
+            (self.path,),
+        )
+        row = await cursor.fetchone()
+        return (time.time() - row[0]) if row else 0

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -9,7 +9,7 @@ from functools import partial
 from inspect import isawaitable
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import AsyncIterator, Awaitable, Callable, cast, Literal
+from typing import AsyncIterator, Awaitable, Callable, Literal, cast
 
 import anyio
 from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group
@@ -488,11 +488,14 @@ class SQLiteYStore(BaseYStore):
 
                 squashed = False
                 if (self.document_ttl is not None and newest_diff > self.document_ttl) or (
-                    self.history_length is not None and oldest_diff > self.min_cleanup_interval + self.history_length
+                    self.history_length is not None
+                    and oldest_diff > self.min_cleanup_interval + self.history_length
                 ):
                     # squash updates
                     ydoc: Doc = Doc()
-                    older_than = time.time() - self.history_length
+                    older_than = time.time() - (
+                        self.history_length if self.history_length is not None else 0
+                    )
                     await cursor.execute(
                         "SELECT yupdate FROM yupdates WHERE path = ? AND timestamp < ?",
                         (self.path, older_than),
@@ -501,7 +504,8 @@ class SQLiteYStore(BaseYStore):
                         ydoc.apply_update(update)
                     # delete older history
                     await cursor.execute(
-                        "DELETE FROM yupdates WHERE path = ? AND timestamp < ?", (self.path, older_than)
+                        "DELETE FROM yupdates WHERE path = ? AND timestamp < ?",
+                        (self.path, older_than),
                     )
                     # insert squashed updates
                     squashed_update = ydoc.get_update()
@@ -524,10 +528,13 @@ class SQLiteYStore(BaseYStore):
                     await self._db.commit()
                     await cursor.execute("VACUUM")
 
-    async def _get_time_differential_to_entry(self, cursor, direction: Literal["ASC", "DESC"] = "DESC") -> float:
-        """ Get the time differential to the newest (DESC) or oldest (ASC) entry in the database. """
+    async def _get_time_differential_to_entry(
+        self, cursor, direction: Literal["ASC", "DESC"] = "DESC"
+    ) -> float:
+        """Get the time differential to the newest (DESC) or oldest (ASC) entry in the database."""
         await cursor.execute(
-            "SELECT timestamp FROM yupdates WHERE path = ? " f"ORDER BY timestamp {direction} LIMIT 1",
+            "SELECT timestamp FROM yupdates WHERE path = ? "
+            f"ORDER BY timestamp {direction} LIMIT 1",
             (self.path,),
         )
         row = await cursor.fetchone()

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -9,7 +9,7 @@ from functools import partial
 from inspect import isawaitable
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import AsyncIterator, Awaitable, Callable, cast, Literal
+from typing import AsyncIterator, Awaitable, Callable, Literal, cast
 
 import anyio
 from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group
@@ -488,7 +488,8 @@ class SQLiteYStore(BaseYStore):
 
                 squashed = False
                 if (self.document_ttl is not None and newest_diff > self.document_ttl) or (
-                    self.history_length is not None and oldest_diff > self.min_cleanup_interval + self.history_length
+                    self.history_length is not None
+                    and oldest_diff > self.min_cleanup_interval + self.history_length
                 ):
                     # squash updates
                     ydoc = Doc()
@@ -501,7 +502,8 @@ class SQLiteYStore(BaseYStore):
                         ydoc.apply_update(update)
                     # delete older history
                     await cursor.execute(
-                        "DELETE FROM yupdates WHERE path = ? AND timestamp < ?", (self.path, older_than)
+                        "DELETE FROM yupdates WHERE path = ? AND timestamp < ?",
+                        (self.path, older_than),
                     )
                     # insert squashed updates
                     squashed_update = ydoc.get_update()
@@ -524,10 +526,13 @@ class SQLiteYStore(BaseYStore):
                     await self._db.commit()
                     await cursor.execute("VACUUM")
 
-    async def _get_time_differential_to_entry(self, cursor, direction: Literal["ASC", "DESC"] = "DESC") -> float:
-        """ Get the time differential to the newest (DESC) or oldest (ASC) entry in the database. """
+    async def _get_time_differential_to_entry(
+        self, cursor, direction: Literal["ASC", "DESC"] = "DESC"
+    ) -> float:
+        """Get the time differential to the newest (DESC) or oldest (ASC) entry in the database."""
         await cursor.execute(
-            "SELECT timestamp FROM yupdates WHERE path = ? " f"ORDER BY timestamp {direction} LIMIT 1",
+            "SELECT timestamp FROM yupdates WHERE path = ? "
+            f"ORDER BY timestamp {direction} LIMIT 1",
             (self.path,),
         )
         row = await cursor.fetchone()

--- a/pycrdt_websocket/ystore.py
+++ b/pycrdt_websocket/ystore.py
@@ -9,7 +9,7 @@ from functools import partial
 from inspect import isawaitable
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import AsyncIterator, Awaitable, Callable, cast
+from typing import AsyncIterator, Awaitable, Callable, cast, Literal
 
 import anyio
 from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group
@@ -323,6 +323,10 @@ class SQLiteYStore(BaseYStore):
     # latest update of a document must be before purging document history.
     # Defaults to never purging document history (None).
     document_ttl: int | None = None
+    # The maximum length of the history of the documents in seconds that is kept.
+    history_length: int | None = 120
+    # The minimum interval in seconds between history cleanup operations.
+    min_cleanup_interval: int = 60
     path: str
     lock: Lock
     db_initialized: Event | None
@@ -478,25 +482,27 @@ class SQLiteYStore(BaseYStore):
             async with self._db:
                 # first, determine time elapsed since last update
                 cursor = await self._db.cursor()
-                await cursor.execute(
-                    "SELECT timestamp FROM yupdates WHERE path = ? "
-                    "ORDER BY timestamp DESC LIMIT 1",
-                    (self.path,),
-                )
-                row = await cursor.fetchone()
-                diff = (time.time() - row[0]) if row else 0
 
-                if self.document_ttl is not None and diff > self.document_ttl:
+                newest_diff = await self._get_time_differential_to_entry(cursor, direction="DESC")
+                oldest_diff = await self._get_time_differential_to_entry(cursor, direction="ASC")
+
+                squashed = False
+                if (self.document_ttl is not None and newest_diff > self.document_ttl) or (
+                    self.history_length is not None and oldest_diff > self.min_cleanup_interval + self.history_length
+                ):
                     # squash updates
                     ydoc: Doc = Doc()
+                    older_than = time.time() - self.history_length
                     await cursor.execute(
-                        "SELECT yupdate FROM yupdates WHERE path = ?",
-                        (self.path,),
+                        "SELECT yupdate FROM yupdates WHERE path = ? AND timestamp < ?",
+                        (self.path, older_than),
                     )
                     for (update,) in await cursor.fetchall():
                         ydoc.apply_update(update)
-                    # delete history
-                    await cursor.execute("DELETE FROM yupdates WHERE path = ?", (self.path,))
+                    # delete older history
+                    await cursor.execute(
+                        "DELETE FROM yupdates WHERE path = ? AND timestamp < ?", (self.path, older_than)
+                    )
                     # insert squashed updates
                     squashed_update = ydoc.get_update()
                     metadata = await self.get_metadata()
@@ -504,6 +510,7 @@ class SQLiteYStore(BaseYStore):
                         "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
                         (self.path, squashed_update, metadata, time.time()),
                     )
+                    squashed = True
 
                 # finally, write this update to the DB
                 metadata = await self.get_metadata()
@@ -511,3 +518,17 @@ class SQLiteYStore(BaseYStore):
                     "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
                     (self.path, data, metadata, time.time()),
                 )
+
+                if squashed:
+                    # Vacuuming database
+                    await self._db.commit()
+                    await cursor.execute("VACUUM")
+
+    async def _get_time_differential_to_entry(self, cursor, direction: Literal["ASC", "DESC"] = "DESC") -> float:
+        """ Get the time differential to the newest (DESC) or oldest (ASC) entry in the database. """
+        await cursor.execute(
+            "SELECT timestamp FROM yupdates WHERE path = ? " f"ORDER BY timestamp {direction} LIMIT 1",
+            (self.path,),
+        )
+        row = await cursor.fetchone()
+        return (time.time() - row[0]) if row else 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "anyio >=3.6.2,<5",
     "sqlite-anyio >=0.2.3,<0.3.0",
-    "pycrdt >=0.10.3,<0.11.0",
+    "pycrdt >=0.10.3,<0.13.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "anyio >=3.6.2,<5",
     "sqlite-anyio >=0.2.3,<0.3.0",
-    "pycrdt >=0.10.1,<0.11.0",
+    "pycrdt >=0.10.3,<0.11.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Currently when using the SQL backend of the ystore the complete document history is stored by default. If the `document_ttl` parameter is set under the specific condition that the time difference between the most recent update and the current update is larger than `document_ttl` all history is squashed. 

At the moment this does not reduce the size of the database and in case of changes to the document that occur relatively regularly no squashing ever takes place. 

This is a draft for discussion of how an effective trimming and limiting of the history size could be achieved. This would address the request to trim the database (https://github.com/jupyter-server/pycrdt-websocket/issues/60) and might also influence the decision to disable the saving of the database (https://github.com/jupyterlab/jupyter-collaboration/issues/244).

To achieve we introduce a new parameter, the `history_length` which limits the age of the oldest entries in the database. All older entries get squashed. Additionally to trim the size of the database deleted entries are vacuumed. This preserves the functionality of the database, e.g. if a client is missing updates we can provide them from the database up to the given age limit.  At the same time the total size does not increase infinitely. This is especially important in contexts where the database is counted towards user quotas.