### PR TITLE
Remove client on failure

### DIFF
--- a/pycrdt_websocket/yroom.py
+++ b/pycrdt_websocket/yroom.py
@@ -309,10 +309,11 @@ class YRoom:
                             tg.start_soon(client.send, message)
                         # apply awareness update to the server's awareness
                         self.awareness.apply_awareness_update(read_message(message[1:]), self)
-                # remove this client
-                self.clients.remove(websocket)
         except Exception as exception:
             self._handle_exception(exception)
+        finally:
+            # remove this client
+            self.clients.remove(websocket)
 
     def send_server_awareness(self, type: str, changes: tuple[dict[str, Any], Any]) -> None:
         """


### PR DESCRIPTION
Resolves #87. Without this I'm getting more and more exceptions as I accumulate more and more disconnected clients. E.g.:

```
    +---------------- 15 ----------------
    | Traceback (most recent call last):
    |   File "/Users/danieldarabos/lynxkite-2000/.venv/lib/python3.11/site-packages/pycrdt_websocket/asgi_server.py", line 33, in send
    |     await self._send(
    |   File "/Users/danieldarabos/lynxkite-2000/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 48, in sender
    |     await send(message)
    |   File "/Users/danieldarabos/lynxkite-2000/.venv/lib/python3.11/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 358, in asgi_send
    |     raise RuntimeError(msg % message_type)
    | RuntimeError: Unexpected ASGI message 'websocket.send', after sending 'websocket.close' or response already completed.
    +---------------- ... ----------------
    | and 3389 more exceptions
    +------------------------------------
```