### PR TITLE
Avoid propagating disconnection message from client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "anyio >=3.6.2,<5",
     "sqlite-anyio >=0.2.3,<0.3.0",
-    "pycrdt >=0.10.3,<0.13.0",
+    "pycrdt >=0.12.13,<0.13.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/455

Should replace https://github.com/jupyterlab/jupyter-collaboration/pull/456

When the client is disconnected (closing a shared document), the websocket server receive a message containing the string `"null"`.

Before this PR, all the messages received from the remote client were propagated to all the clients (including itself to keep the connection alive). This was raising an error in console because the client was disconnected and it was therefore not possible to send it a message.

This PR read the message, and if it is a disconnection message, it avoids propagating it to itself.


