### PR TITLE
fix: add missing exception handler to YRoom instantiation in get_room

### DIFF
--- a/src/pycrdt/websocket/websocket_server.py
+++ b/src/pycrdt/websocket/websocket_server.py
@@ -92,7 +92,7 @@ class WebsocketServer:
                 else None
             )
             self.rooms[name] = YRoom(
-                ready=self.rooms_ready, log=self.log, provider_factory=provider_factory
+                ready=self.rooms_ready, exception_handler=self.exception_handler, log=self.log, provider_factory=provider_factory
             )
         room = self.rooms[name]
         await self.start_room(room)

--- a/src/pycrdt/websocket/websocket_server.py
+++ b/src/pycrdt/websocket/websocket_server.py
@@ -92,7 +92,10 @@ class WebsocketServer:
                 else None
             )
             self.rooms[name] = YRoom(
-                ready=self.rooms_ready, exception_handler=self.exception_handler, log=self.log, provider_factory=provider_factory
+                ready=self.rooms_ready,
+                exception_handler=self.exception_handler,
+                log=self.log,
+                provider_factory=provider_factory,
             )
         room = self.rooms[name]
         await self.start_room(room)


### PR DESCRIPTION
## Problem
`get_room` creates `YRoom` without passing `exception_handler`, causing exceptions to be unhandled.

## Changes
Add `exception_handler=self.exception_handler` to `YRoom` instantiation.